### PR TITLE
OPEN: Remove warnings during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,18 @@ target_compile_options(pulp-nn-mixed PRIVATE
   -Wno-incompatible-pointer-types
   -Wno-implicit-function-declaration
   -Wno-attributes
-  -Wno-discarded-qualifiers
   -Wno-pointer-sign
   -Wno-unused-value
   -Wno-int-conversion
   -Wno-typedef-redefinition
   -Wno-uninitialized
 )
+
+if(TOOLCHAIN STREQUAL LLVM)
+  target_compile_options(pulp-nn-mixed PRIVATE -Wno-ignored-qualifiers)
+else()
+  target_compile_options(pulp-nn-mixed PRIVATE -Wno-discarded-qualifiers)
+endif()
 
 target_include_directories(pulp-nn-mixed PRIVATE ${PULP_SDK_INCLUDES})
 target_compile_options(pulp-nn-mixed PRIVATE ${PULP_SDK_COMPILE_FLAGS})


### PR DESCRIPTION
- When compiling with LLVM the `Wno-discarded-qualifiers`generates errors.
```
warning: unknown warning option '-Wno-discarded-qualifiers'; did you mean '-Wno-ignored-qualifiers'? [-Wunknown-warning-option]
```

# Changelog
- Adjust CMakeLists.txt to work with LLVM and GCC