### PR TITLE
OPEN: Fix repeated pulp-skd include dirs and compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,6 @@ target_compile_options(pulp-nn-mixed PRIVATE
   -Wno-int-conversion
 )
 
-target_include_directories(pulp-nn-mixed PUBLIC ${PULP_SDK_INCLUDES})
-target_compile_options(pulp-nn-mixed PUBLIC ${PULP_SDK_COMPILE_FLAGS})
-
 if(PULPNNVERSION STREQUAL XPULPV2)
   if(PULPNNBITWIDTH STREQUAL 32)
     set(INCLUDES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(PULPNNMIXED)
+
+add_library(pulp-nn-mixed STATIC)
+
+target_compile_options(pulp-nn-mixed PRIVATE
+  -Ofast
+  -Wno-conversion
+  -Wno-sign-compare
+  -Wno-sign-conversion
+  -Wno-unused-variable
+  -Wno-unused-function
+  -Wno-unused-parameter
+  -Wno-incompatible-pointer-types
+  -Wno-implicit-function-declaration
+  -Wno-attributes
+  -Wno-discarded-qualifiers
+  -Wno-pointer-sign
+  -Wno-unused-value
+  -Wno-int-conversion
+)
+
+target_include_directories(pulp-nn-mixed PUBLIC ${PULP_SDK_INCLUDES})
+target_compile_options(pulp-nn-mixed PUBLIC ${PULP_SDK_COMPILE_FLAGS})
+
+if(PULPNNVERSION STREQUAL XPULPV2)
+  if(PULPNNBITWIDTH STREQUAL 32)
+    set(INCLUDES
+      ${CMAKE_CURRENT_LIST_DIR}/XpulpV2/32bit/include
+    )
+    file(GLOB_RECURSE SRC
+      XpulpV2/32bit/src/**/*.c
+    )
+  endif()
+endif()
+
+target_include_directories(pulp-nn-mixed PUBLIC
+  ${INCLUDES}
+)
+target_sources(pulp-nn-mixed PRIVATE ${SRC})
+set(PULPNN_INCLUDES ${INCLUDES} CACHE INTERNAL "PULPNN_INCLUDES")


### PR DESCRIPTION
Adding pulp-sdk include dirs and compiler flags is already done in deeploypulplibs.